### PR TITLE
Ignore inadvertent joystick twists

### DIFF
--- a/src/main/java/org/usfirst/frc/team4828/DriveTrain.java
+++ b/src/main/java/org/usfirst/frc/team4828/DriveTrain.java
@@ -49,6 +49,11 @@ public class DriveTrain {
      * Adjust motor speeds according to joystick input
      */
     public void mecanumDrive(double x, double y, double rotation) {
+        // Ignore tiny inadvertent joystick rotations
+        if (Math.abs(rotation) <= 0.15) {
+             rotation = 0.0;
+        }
+        
         // Negate y for the joystick.
         y = -y;
 
@@ -71,6 +76,11 @@ public class DriveTrain {
      * use input from the gyroscope to determine field orientation
      */
     public void mecanumDrive(double x, double y, double rotation, double gyroAngle) {
+        // Ignore tiny inadvertent joystick rotations
+        if (Math.abs(rotation) <= 0.15) {
+             rotation = 0.0;
+        }
+        
         // Negate y for the joystick.
         y = -y;
         // Compensate for gyro angle.


### PR DESCRIPTION
Drivers may end up twisting the joystick up to ±0.2 (value of `driveStick.getTwist() / 2`) when moving laterally. Ignore joystick rotation amounts less than 0.15 to avoid accidental turning. Minimum useful rotation amount is approximately ±0.3.