### PR TITLE
Improve Travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,18 @@ addons:
       - junit4
   code_climate:
           repo_token: 3196bfa644b36e30bf8c3d41c51d36d7eb39fc0d54739268ffc677170d1b26d0
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 before_install:
   - chmod +x gradlew
 script:
   - ./gradlew $TEST_SUITE
-  
+
 # For CodeCov
 after_success:
   - ./gradlew test jacocoTestReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ cache:
     - $HOME/.gradle/wrapper/
 before_install:
   - chmod +x gradlew
-script:
-  - ./gradlew $TEST_SUITE
+install: echo "skip 'gradle assemble' step"
+script: gradle build --continue
 
 # For CodeCov
 after_success:
@@ -36,5 +36,3 @@ cards:
   - master
   - development
   title: Toast
-env:
-  - TEST_SUITE=build

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,3 @@ cards:
   title: Toast
 env:
   - TEST_SUITE=build
-  - TEST_SUITE=check

--- a/src/test/java/org/usfirst/frc/team4828/DriveTrainTest.java
+++ b/src/test/java/org/usfirst/frc/team4828/DriveTrainTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
  * @see DriveTrain
  */
 public class DriveTrainTest {
-    private static final int TEST_CASES = 420420;
+    private static final int TEST_CASES = 420;
 
     /**
      * Tests the Normalization function in DriveTrain Class


### PR DESCRIPTION
- Run just 420 tests instead of 420420 🔥 
- Run just `gradlew build` instead of `build` and `check`, because `build` is just `assemble` and `check`
- Cache gradle wrapper and some dependencies